### PR TITLE
make schedule a toplevel page with navbar link

### DIFF
--- a/themes/gophercon/layouts/index.html
+++ b/themes/gophercon/layouts/index.html
@@ -32,6 +32,7 @@
                   <li><a class="inner-link" href="/code-of-conduct">Code of Conduct</a></li>
                   <li><a class="inner-link" href="/speakers">Speakers</a></li>
                   <li><a class="inner-link" href="/sessions">Sessions</a></li>
+                  <li><a class="inner-link" href="/schedule">Schedule</a></li>
                   <li><a class="inner-link" href="/sponsors">Sponsors</a></li>
 								</ul>
 								<div class="mobile-menu-toggle"><i class="icon icon_menu"></i></div>

--- a/themes/gophercon/layouts/partials/navbar.html
+++ b/themes/gophercon/layouts/partials/navbar.html
@@ -22,6 +22,7 @@
             <li><a class="inner-link" href="/code-of-conduct">Code of Conduct</a></li>
             <li><a class="inner-link" href="/speakers">Speakers</a></li>
             <li><a class="inner-link" href="/sessions">Sessions</a></li>
+            <li><a class="inner-link" href="/schedule">Schedule</a></li>
             <li><a class="inner-link" href="/sponsors">Sponsors</a></li>
           </ul>
           <div class="mobile-menu-toggle"><i class="icon icon_menu"></i></div>

--- a/themes/gophercon/layouts/partials/schedule.html
+++ b/themes/gophercon/layouts/partials/schedule.html
@@ -1,5 +1,10 @@
-    <section class="content schedule">
-        <div class="container">
+    <section id="schedule" class="content schedule">
+      <div class="container">
+          <div class="row">
+            <div class="col-sm-12">
+              <h1>Schedule</h1>
+            </div>
+          </div>
           <div class="row">
             <div class="col-md-10 col-md-offset-1 text-center">
               <ul class="nav nav-tabs schedule-days">

--- a/themes/gophercon/layouts/section/schedule.html
+++ b/themes/gophercon/layouts/section/schedule.html
@@ -1,23 +1,11 @@
 {{ partial "header.html" . }}
 
+<body>
+  {{ partial "navbar.html" . }}
+  <div class="main-container">
+    {{ partial "schedule.html" . }}
+  </div>
 
-<main class="container generic">
-    <section class="row"> 
-        <div class="col-md-8">
-          <h2>Schedule</h2>
-          {{ range (.Data.Pages).Reverse }}
-            <h3><a href="{{ .RelPermalink }}">{{ .Title }}</a></h3>
-            <small>{{ dateFormat "Monday, Jan 2, 2006" .Date }}</small><br/><br/>
-            {{ .Summary }}
-            {{ if .Truncated }} <br/><br/>
-            <a class="readmore" href="{{ .RelPermalink }}">Read More <i class="fa fa-arrow-circle-right"></i></a>
-            {{ end }}
-          {{ end }}
-        </div>
-
-    </section>
-</main>
-<main>
   {{ partial "sponsors.html" . }}
-</main>
+
 {{ partial "footer.html" . }}


### PR DESCRIPTION
On the main page the schedule is way down below all the speakers and it
seems to me like people aren't finding it.  Add it as a link in the
navbar and make it its own toplevel page at /schedule.