### PR TITLE
use Site scope rather than Data for getting speakers for schedule

### DIFF
--- a/themes/gophercon/layouts/partials/schedule/11july.html
+++ b/themes/gophercon/layouts/partials/schedule/11july.html
@@ -1,5 +1,4 @@
-
-                {{ $sessions := where (where .Data.Pages "Section" "sessions") "Params.sessionscheduled" "July 11th" }}
+                {{ $sessions := where (where .Site.Pages "Section" "sessions") "Params.sessionscheduled" "July 11th" }}
                 <div id="day1-schedule" class="tab-pane schedule-tab tab-pane-subtabs">
                   <ul class="nav nav-tabs">
                     <li role="presentation" class="active">

--- a/themes/gophercon/layouts/partials/schedule/12july.html
+++ b/themes/gophercon/layouts/partials/schedule/12july.html
@@ -1,5 +1,5 @@
 
-                {{ $sessions := where (where .Data.Pages "Section" "sessions") "Params.sessionscheduled" "July 12th" }}
+                {{ $sessions := where (where .Site.Pages "Section" "sessions") "Params.sessionscheduled" "July 12th" }}
                 <div id="day2-schedule" class="tab-pane schedule-tab tab-pane-subtabs">
                   <ul class="nav nav-tabs">
                     <li role="presentation" class="active">


### PR DESCRIPTION
The schedule partials do filtering of pages to get speaker info for the
schedule.  When the schedule is on the main page, using .Data.Pages
works fine, since all pages are children of the toplevel.  But on
/schedule that doesn't work, so use .Site.Pages instead.

Fixes the problem where /schedule only showed all the breaks, but none
of the actual speaker sessions.