### PR TITLE
Remove loader modal box from index.html

### DIFF
--- a/themes/gophercon/layouts/index.html
+++ b/themes/gophercon/layouts/index.html
@@ -1,12 +1,5 @@
   {{ partial "header.html" . }}
     <body>
-      <div class="loader">
-        <div class="strip-holder">
-          <div class="strip-1"></div>
-          <div class="strip-2"></div>
-          <div class="strip-3"></div>
-        </div>
-      </div>
     	<a id="top"></a>
       <div class="nav-container">
 				<nav class="overlay-nav">

--- a/themes/gophercon/static/2016/js/scripts.js
+++ b/themes/gophercon/static/2016/js/scripts.js
@@ -126,13 +126,4 @@ $(window).load(function() {
             forceHeight: false
         });
     }
-
-    setTimeout(function() {
-        $('.loader').addClass('hide-loader');
-        setTimeout(function() {
-            $('.loader').remove();
-            $('.main-container').addClass('show-content');
-            $('nav').addClass('show-content');
-        }, 500);
-    }, 10);
 }); 


### PR DESCRIPTION
The loader logic was stalling until _all_ the content was loaded ... yup
every, single, image. Combined with enforced https which means nothing
is cached on the client it meant the loader would obscure the index page
for 30 seconds.

This must be killing our views and ticket sales.

You can see a sample of what this looks like at http://gophercon9000.cheney.net/