### PR TITLE
Add RSVP info for the Kickoff and After Parties

### DIFF
--- a/content/events/afterparty.md
+++ b/content/events/afterparty.md
@@ -17,12 +17,16 @@ Outdoors, an additional space with bistro lights strung overhead, will feature a
 
 More Information can be found here: [Punch Bowl Social](http://punchbowlsocial.com/denver/) 
 
+## RSVP
+
+RSVP not required.
+
 ## Transportation
 Transportation will be provided. We will have (5) 54-passenger motorcoaches running conitunous shuttle service between Punch Bowl Social and the Convention Center where the hotels are located.
 
 Shuttle Service departs from the corner of 14th and Welton Streets downtown in front of the Colorado Convention Center (across from the Hyatt Regency) ~ Run Time is 7:45p – 11:15p.
 
-### Address
+## Address
 Punch Bowl Social
 
 65 Broadway

--- a/content/events/preparty.md
+++ b/content/events/preparty.md
@@ -23,7 +23,11 @@ As we get closer to the date, more details will be announced.
 
 More Information can be found here: [Denver Gophers](http://www.meetup.com/Denver-Go-Language-User-Group/events/229341754/) 
 
-### Address
+## RSVP
+
+RSVP for the Event here: [Denver Gophers](http://www.meetup.com/Denver-Go-Language-User-Group/events/229341754/)
+
+## Address
 Wynkoop Brewing Company
 
 1634 18th St.


### PR DESCRIPTION
What
===
Add RSVP information for the Kickoff and After Parties.

Why
===
The Kickoff Party is hosted by the Denver Gophers Meetup and according to
https://twitter.com/GopherCon/status/746366250658439168 we need to RSVP
for the event, regardless of whether we have GopherCon tickets. This
isn't clear on the event page, and this change makes it explicit.

According to https://twitter.com/GopherCon/status/746373067400699904 the
After Party does not have an RSVP. Adding this section to this event
makes this clear.

Screenshots
===
<img src="https://cloud.githubusercontent.com/assets/351529/16344593/38c33b64-39f2-11e6-9286-5760bac8bf8b.png" width="50%" alt="Kickoff Party Screenshot" /><img src="https://cloud.githubusercontent.com/assets/351529/16344596/3de45b28-39f2-11e6-8b16-292d5023b9d0.png" width="50%" alt="After Party Screenshot" />
