### PR TITLE
Add DIA to Denver transportation information.

### DIFF
--- a/content/location.md
+++ b/content/location.md
@@ -10,11 +10,22 @@ subtitle = "Downtown Denver"
 ## Colorado Convention Center
 Opened in 1990, with more than 100 professional meeting planners working together with architects to design every aspect of the building, the result was simple; a sensible, state-of-the-art facility with easy traffic flow and everything you need in a stunningly beautiful building in the heart of downtown Denver. Expanded in 2005, well-known as one of the most practical and “user friendly” meeting facilities, the Colorado Convention Center is now home to over 250+ events annually. The Colorado Convention Center is located within easy walking distance of over 8,700 hotel rooms, 300 restaurants, 9 theatres of the Denver Performing Arts Complex and a wide variety of shopping and retail outlets.
 
-More Information can be found here: [Colorado Convention Center](http://denverconvention.com) 
+More Information can be found here: [Colorado Convention Center](http://denverconvention.com)
 
+---
 ### Address
 	Colorado Convention Center
 	700 14th Street
 	Denver, Colorado 80202
 
 <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d3067.8723967161754!2d-104.99639859999999!3d39.7425171!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x876c78d19ee5341f%3A0x3d2bbf54ad753723!2s700+14th+St%2C+Denver%2C+CO+80202!5e0!3m2!1sen!2sus!4v1431656220832" width="600" height="450" frameborder="0" style="border:0"></iframe>
+
+---
+### DIA (Denver International Airport) To Union Station (Downtown Denver)
+
+You have a few options for traveling from the airport to downtown. In addition to the standard cab/rideshare services (all available at the Ground Transportation area of DIA), there are two primary public transportation options. The [RTD A-Line Train](http://www.rtd-denver.com/a-line.shtml) is a recent addition to the public transportation options which will get you from DIA to Union Station in 37 minutes for $9 USD. There are also a few bus options available through the [RTD Bus System](http://www.rtd-denver.com/airport.shtml) though they are more expensive and generally take longer than the new train.
+
+---
+### Union Station To Hotels
+
+Getting from Union Station to your hotel is also easy thanks to the free [MallRide](http://www.rtd-denver.com/FREEMallRide.shtml) which will get you anywhere along the 16th Street corridor (where most of the downtown hotels are) for free! You can also get a cab/rideshare from Union Station to any of the hotels for very cheap (usually less than $5 USD).


### PR DESCRIPTION
Adds information about traveling from DIA to Denver to the About - Location section.

![screen shot 2016-06-27 at 2 00 10 pm](https://cloud.githubusercontent.com/assets/5130441/16393823/85596e7e-3c6f-11e6-8aba-036389197219.png)

I added the line breaks to give the content on the page a bit of spacing (it was looking very crowded).