### PR TITLE
Added lightning talk details and link to signup page

### DIFF
--- a/content/lightning-talks.md
+++ b/content/lightning-talks.md
@@ -1,0 +1,67 @@
++++
+author = ["Mark Bates", "Steve Francia"]
+date = "2015-07-01T16:03:09-04:00"
+linktitle = "Lightning Talks"
+title = "Lightning Talks"
+subtitle = ""
++++
+# GopherCon 2016 Lightning Talks
+
+Lightning talks will be held in the Mile High Ballroom from 4:30pm til 6:00pm on both Monday the 11th of July and Tuesday the 12th of July.
+Each session will have 10 - 12 speakers.
+
+## Submissions
+
+Submit you lightning talk proposal here:
+
+[GopherCon 2016 Lightning Talks](https://www.papercall.io/gophercon-lightning-talks-2016)
+
+The submission deadline is 10:00am 11 July 2016.
+
+## Lightning Talk Ground Rules
+
+<ul style="list-style: disc;">
+<li>Talks are 6 minutes each. After that, the mic is turned off.</li>
+<li>1 minute for questions while the next speaker is setting up (you can use more if your talk ends early).</li>
+<li>You’ll get one warning at the 5½ min mark.</li>
+<li>Slides are encouraged, but not required, and you can flip them at your own pace.</li>
+<li>Demos are allowed, but please be mindful of the time and plan ahead for technical issues.</li>
+<li>You can submit as many talks as you like, but to be fair to others, we’ll only choose at most one talk.</li>
+<li>All talks must adhere to the GopherCon [Code of Conduct](http://gophercon.com/code-of-conduct/).</li>
+</ul>
+
+## Why give a lightning talk?
+(taken shamelessly from Yapc’s instructions on lightning talks).
+
+Maybe you’ve never given a talk before, and you’d like to start small. For a Lightning Talk, you don’t need to make slides, and if you do decide to make slides, you only need to make three.
+
+Maybe you’re nervous and you’re afraid you’ll mess up. It’s a lot easier to plan and deliver a seven minute talk than it is to deliver a long talk. And if you do mess up, at least the painful part will be over quickly.
+
+Maybe you don’t have much to say. Maybe you just want to ask a question, or invite people to help you with your project, or boast about something you did, or tell a short cautionary story. These things are all interesting and worth talking about, but there might not be enough to say about them to fill up thirty minutes.
+
+Here are some suggestions for awesome lightning talks that I’d like to see at GopherCon this year, and of course this list isn’t exclusive, it’s your seven minutes of fame.
+
+<ul style="list-style: disc;">
+<li>Why my favorite library is X.</li>
+<li>I want to do cool project X. Does anyone want to help?</li>
+<li>Successful Project: I did project X. It was a success. Here’s how you could benefit.</li>
+<li>Failed Project: I did project X. It was a failure, and here’s why.</li>
+<li>Heresy: People always say X, but they’re wrong. Here’s why.</li>
+<li>Here a few things our community needs to do better.</li>
+<li>Call to Action: Let’s all do more of X / less of X.</li>
+<li>Wouldn’t it be cool if X?</li>
+<li>Someone needs to do X.</li>
+<li>I wish Go had.</li>
+<li>Why X was a mistake.</li>
+<li>Why X looks like a mistake, but isn’t.</li>
+<li>What it’s like to do X.</li>
+<li>Here’s a useful technique that worked.</li>
+<li>Here’s a technique I thought would be useful but didn’t work.</li>
+<li>Why algorithm X sucks.</li>
+<li>Comparison of algorithms X and Y.</li>
+</ul>
+
+We look forward to hearing you share your remarkable and inspiring stories, projects and messages.
+ 
+
+

--- a/themes/gophercon/layouts/partials/navbar.html
+++ b/themes/gophercon/layouts/partials/navbar.html
@@ -40,6 +40,7 @@
                 <li><a class="inner-link" href="/schedule">Schedule</a></li>
                 <li><a class="inner-link" href="/speakers">Speakers</a></li>
                 <li><a class="inner-link" href="/sessions">Sessions</a></li>
+                <li><a class="inner-link" href="/lightning-talks">Lightning Talks</a></li>
               </ul>
             </li>
             <li class="has-dropdown">

--- a/themes/gophercon/layouts/partials/schedule/11july.html
+++ b/themes/gophercon/layouts/partials/schedule/11july.html
@@ -103,7 +103,7 @@
 
                       {{ partial "schedule/intermission.html" (dict "purpose" "Speakers’ Q & A Panel" "sessiontime" "03:30pm - 04:20pm" )}}
 
-                      {{ partial "schedule/intermission.html" (dict "purpose" "Lightning Talks" "sessiontime" "04:30pm - 06:00pm" )}}
+                      {{ partial "schedule/lightning-talk.html" (dict "sessiontime" "04:30pm - 06:00pm" )}}
 
                     </div>
                     <div id="tutorial-1-11july" class="schedule-tab schedule-item-tab tab-pane">

--- a/themes/gophercon/layouts/partials/schedule/12july.html
+++ b/themes/gophercon/layouts/partials/schedule/12july.html
@@ -79,7 +79,7 @@
 
                       {{ partial "schedule/intermission.html" (dict "purpose" "Speakers’ Q & A Panel" "sessiontime" "03:30pm - 04:20pm" )}}
 
-                      {{ partial "schedule/intermission.html" (dict "purpose" "Lightning Talks" "sessiontime" "04:30pm - 06:00pm" )}}
+                      {{ partial "schedule/lightning-talk.html" (dict "sessiontime" "04:30pm - 06:00pm" )}}
 
                     </div>
                     <div id="tutorial-1-12july" class="schedule-tab schedule-item-tab tab-pane">

--- a/themes/gophercon/layouts/partials/schedule/lightning-talk.html
+++ b/themes/gophercon/layouts/partials/schedule/lightning-talk.html
@@ -1,0 +1,14 @@
+
+                      <div class="row schedule-item">
+                        <div class="col-md-3 schedule-item-slot">
+                          <span class="time">{{ .sessiontime }}</span>
+                        </div>
+                        <div class="col-md-9 schedule-item-details">
+                          <div class="schedule-item-summary">
+                            <span class="title">Lightning Talks</span>
+			    <div class="abstract">
+			      <a href="/lightning-talks">Lightning talk details and signup form</a>
+	                    </div>
+                          </div>
+                        </div>
+                      </div>


### PR DESCRIPTION
This PR adds
- a details page for the lightning talks
- a link from the schedule pulldown on the top nav
- a link from the 11th and 12th pages to the details page.
